### PR TITLE
add fetch options

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ const middleWare = (module.exports = function(options) {
           path.join(options.cacheDir, dir1, dir2, dir3)
         );
 
-        const blob = await (await fetch(res.locals.fetchUrl)).blob();
+        const blob = await (await fetch(res.locals.fetchUrl, res.locals.options)).blob();
 
         const fileName = middleWare.encodeAssetCacheName(blob.type, blob.size);
 


### PR DESCRIPTION
add fetch options to pass headers

In some cases we need to pass api-key or something else.

For example:
```
app.get("/WebClient/*", 
  async (req, res, next) => {
    res.locals.fetchUrl = `http://someapi.ru/WebClient/${req.params[0]}?${encodeQuery(req.query)}`;
    res.locals.options = { headers: req.headers }
    next();
  },
  fileCacheMiddleware({ cacheDir, maxSize: 10 * 1024 * 1024 * 1024 * 1024 }),
  (req, res) => {
    res.set({
      "Content-Type": res.locals.contentType,
      "Content-Length": res.locals.contentLength
    });
    res.end(res.locals.buffer, "binary");
  }
);
```