### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration for scheduled version updates.
+# Security updates (for known vulnerabilities) are configured separately in
+# the repo's Security settings; this file enables routine dependency bumps.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # npm dependencies (package.json / package-lock.json in the repo root)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # GitHub Actions used by the workflows in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Why

Dependabot went quiet on this repo. Investigating turned up two separate causes:

1. **No `.github/dependabot.yml`.** There was never a version-updates config, so Dependabot only ever opened *security*-update PRs (e.g. #19). Routine dependency bumps never ran.
2. **Security updates are paused.** `automated-security-fixes` reports `{"enabled": true, "paused": true}` — GitHub auto-pauses security updates after a long stretch without interacting with Dependabot PRs. That's why the 9 open alerts (1 critical / 2 high / 6 moderate) produced no PRs.

## What this PR does

Adds `.github/dependabot.yml` enabling weekly version-update PRs for:

- **npm** (`package.json` / `package-lock.json`)
- **github-actions** (the workflows under `.github/workflows`)

Merging this to `master` triggers an initial Dependabot run.

## Manual step still needed (can't be done from the API)

Re-enabling via `PUT /automated-security-fixes` does **not** clear the `paused` flag. To resume the paused **security** updates, do one of:

- Open **Security → Dependabot alerts** and use the "resume" prompt on the paused banner, or
- Merge the first version-update PR this config produces — interacting with any Dependabot PR resumes security updates automatically.

Once resumed, Dependabot will start opening PRs for the 9 existing vulnerability alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
