### PR TITLE
Stop CI running twice per change

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,16 @@
 name: Node CI
 
-on: [push, pull_request]
+on:
+  # Only run once per change: `pull_request` covers branches with an open PR,
+  # and `push` is scoped to master so it doesn't double up with the PR run.
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  # Cancel superseded runs for the same branch/PR (e.g. rapid pushes).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Why

With `on: [push, pull_request]`, any branch that has an open PR triggers **both** a `push` run and a `pull_request` run. With the 3-version matrix that's **6 jobs per change** — half of them redundant.

## Change

`nodejs.yml`:
- scope `push` to `branches: [master]` (direct pushes to the default branch still run; feature branches are covered by the `pull_request` event)
- add a `concurrency` group keyed on the ref with `cancel-in-progress: true`, so a new push cancels the still-running jobs for the same branch/PR

Net effect: one run per change instead of two, and superseded runs get cancelled automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
