### PR TITLE
Fix touch() truncating cached assets when utimesSync fails (#42)

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,11 @@ function touch(path) {
   const time = new Date();
   try {
     fs.utimesSync(path, time, time);
-  } catch (err) {
-    fs.closeSync(fs.openSync(path, "w"));
+  } catch (_) {
+    // Best-effort LRU timestamp bump. If utimesSync fails, leave the file
+    // untouched: the previous fallback opened it with the "w" flag, which
+    // truncated the cached asset to zero bytes (#42). LRU accuracy is never
+    // worth corrupting a cached file.
   }
 }
 

--- a/test/touch.test.mjs
+++ b/test/touch.test.mjs
@@ -1,0 +1,58 @@
+// Regression tests for touch() (issue #42). Written as a standalone ESM file
+// so it coexists with the CommonJS test/test.js on master today and with the
+// ESM test/test.mjs once the streaming PR lands - no shared file to conflict
+// on. Uses node:assert (not chai) so it is independent of the chai major
+// version, which differs between those two branches.
+import assert from "node:assert";
+import sinon from "sinon";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import middleware from "../index.js";
+
+describe("touch", function() {
+  let dir;
+
+  beforeEach(function() {
+    // Clear any sinon stubs an earlier suite left on fs. The CommonJS
+    // test/test.js on master stubs fs methods without fully restoring them,
+    // and mocha runs all spec files in one process. (The ESM test/test.mjs
+    // that replaces it fixes those leaks, so this is a no-op there.)
+    sinon.restore();
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "touch-test-"));
+  });
+
+  afterEach(function() {
+    sinon.restore();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not truncate the cached file when utimesSync fails", function() {
+    const file = path.join(dir, "asset");
+    const contents = Buffer.from("important cached bytes");
+    fs.writeFileSync(file, contents);
+
+    // Force the timestamp bump to fail; the old fallback opened the file with
+    // "w" here, truncating it to zero bytes.
+    sinon.stub(fs, "utimesSync").throws(new Error("EPERM"));
+
+    middleware.touch(file);
+
+    assert.ok(
+      fs.readFileSync(file).equals(contents),
+      "cached file must not be truncated when utimesSync fails"
+    );
+  });
+
+  it("bumps the timestamp via utimesSync on success", function() {
+    const file = path.join(dir, "asset");
+    fs.writeFileSync(file, Buffer.from("x"));
+
+    const spy = sinon.spy(fs, "utimesSync");
+
+    middleware.touch(file);
+
+    assert.ok(spy.calledWith(file), "utimesSync should be called with the path");
+  });
+});


### PR DESCRIPTION
Fixes #42.

## Problem

`touch()` bumps a cache file's timestamps for LRU on every cache **hit**. When `fs.utimesSync` fails, the fallback ran:

```js
fs.closeSync(fs.openSync(path, "w"));
```

`openSync(path, "w")` opens the existing cache file **with truncation**, zeroing the asset. It's then served empty and the corrupted entry persists. This corrupts data on **Windows** too — the project's primary target.

## Fix

Drop the truncating fallback. A failed timestamp update is now a best-effort no-op: LRU ordering degrades gracefully, but a cached file is never destroyed.

## Test

Added `test/touch.test.mjs` (standalone ESM, `node:assert`): asserts the cached file is intact when `utimesSync` throws, and that `utimesSync` is used on the happy path.

## No merge conflict with #27

This branch deliberately touches only:
- `index.js` `touch()` — a function #27 does **not** modify, so it 3-way-merges automatically either merge order.
- a **new** test file — no overlap with #27's `test/test.js` → `test/test.mjs` rename, and it's picked up by both master's default mocha glob and #27's `test/*.mjs` spec. It uses `node:assert` (not chai) so it's independent of the chai major-version difference between the two branches.

_Note: this branch is off `master`, whose runtime `evictLeastRecentlyUsed` is currently broken against get-folder-size v5 (fixed by #27) — unrelated to this change, and not exercised by CI._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
