### PR TITLE
Extract a reusable cacheAsset(url, opts) for non-Express callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,38 @@ The asset's `contentType` and `contentLength` are stored base64 encoded in the f
 
 Note that setting `cacheKey` and `cacheDir` isn't strictly necessary, it will fall back to `res.local.fetchUrl` and `path.join(process.cwd(), "/tmp")`, respectively.
 
+## Using it without express: `cacheAsset`
+
+Since 1.6.0 the fetch+cache core is exported on its own, so callers that aren't serving an HTTP request (an Electron main process, a CLI precache, a queue worker) get the same streaming download, atomic rename, LRU accounting and progress reporting without standing up a local server:
+
+```javascript
+const { cacheAsset } = require("express-asset-file-cache-middleware");
+
+const result = await cacheAsset("https://cdn.example.org/big-video.mp4", {
+  cacheDir: "/tmp",
+  cacheKey: someExpirableUniqueKey, // optional, falls back to the URL
+  onProgress: ({ received, total }) => {
+    mainWindow.webContents.send("download:progress", { received, total });
+  }
+});
+
+if (result.status === "cached") {
+  console.log(result.path, result.contentType, result.contentLength);
+}
+```
+
+It resolves to one of three shapes:
+
+| `status`   | Meaning | Fields |
+| ---------- | ------- | ------ |
+| `"cached"` | The asset is on disk and ready to read. | `fromCache` (`false` on a fresh download, `true` on a cache hit), `path`, `contentType`, `contentLength` |
+| `"error"`  | Non-2xx upstream. Nothing was cached; the entry self-heals on the next call. | `httpStatus`, `statusText`, `contentType`, `body` |
+| `"empty"`  | 2xx carrying no body (204/205). Nothing was cached. | `httpStatus` |
+
+Filesystem and stream errors reject instead. `cacheAsset` unlinks its own temp file first, so a failed download never leaves a partial entry behind.
+
+The options are the middleware's (`cacheDir`, `maxSize`, `logger`, `onProgress`) plus `cacheKey`, which the middleware takes from `res.locals.cacheKey`. The middleware is a thin adapter over this function, so both paths share one implementation and behave identically.
+
 ## LRU Eviction
 
 To avoid cluttering your device, an LRU (least recently used) cache eviction strategy is in place. Per default, when your cache dir grows over 1 GB of size, the least recently used (accessed) files will be evicted (deleted), until enough disk space is available again. You can change the cache dir size by specifying `options.maxSize` (in bytes) when creating the middleware.

--- a/index.js
+++ b/index.js
@@ -197,176 +197,236 @@ function findLeastRecentlyUsed(dir, result) {
   return result;
 }
 
+/**
+ * Fetch an asset and cache it on disk, or resolve it straight from the cache.
+ *
+ * This is the whole download/cache/progress core with no HTTP transport
+ * attached, so a non-Express caller (an Electron main process, a CLI precache,
+ * a queue worker) can use it directly. The middleware below is a thin adapter
+ * over it.
+ *
+ * @param {string} fetchUrl
+ * @param {object} [opts]
+ * @param {string} [opts.cacheDir=<cwd>/tmp]
+ * @param {string} [opts.cacheKey=fetchUrl] cache path / dedupe key
+ * @param {number} [opts.maxSize=1GiB] LRU ceiling for the cache directory
+ * @param {(progress: { received: number, total: number|null }) => void} [opts.onProgress]
+ *   Called per chunk on a cache miss. `total` comes from Content-Length and is
+ *   null when the upstream response is chunked.
+ * @param {object} [opts.logger]
+ * @returns {Promise<
+ *   | { status: "cached", fromCache: boolean, path: string, contentType: string, contentLength: string }
+ *   | { status: "error", httpStatus: number, statusText: string, contentType: string|null, body: string }
+ *   | { status: "empty", httpStatus: number }
+ * >}
+ *   Rejects on filesystem/stream errors, after unlinking its own temp file.
+ */
+async function cacheAsset(fetchUrl, opts) {
+  opts = opts || {};
+  const cacheDir = opts.cacheDir || path.join(process.cwd(), "/tmp");
+  const maxSize = opts.maxSize || 1024 * 1024 * 1024;
+  const cacheKey = opts.cacheKey || fetchUrl;
+  const logger = opts.logger;
+
+  const {
+    dir1,
+    dir2,
+    dir3,
+    path: assetCachePath
+  } = middleWare.makeAssetCachePath(cacheDir, cacheKey);
+
+  // Scoped here so the catch block can clean up this call's temp file without
+  // removing the shared cache directory, which a concurrent call for the same
+  // key may be using.
+  let tmpPath;
+  const startTime = process.hrtime();
+
+  try {
+    if (fs.existsSync(assetCachePath)) {
+      const firstFile = fs.readdirSync(assetCachePath)[0];
+
+      // Empty directory = corrupted cache entry, re-fetch
+      if (!firstFile) {
+        fs.rmdirSync(assetCachePath);
+        // Fall through to the fetch path by pretending the dir doesn't exist
+        return middleWare.cacheAsset(fetchUrl, opts);
+      }
+
+      // touch file for LRU eviction
+      middleWare.touch(`${assetCachePath}/${firstFile}`);
+
+      const [contentType, contentLength] = middleWare.decodeAssetCacheName(
+        firstFile
+      );
+
+      const [seconds, nanoSeconds] = process.hrtime(startTime);
+      if (logger)
+        logger.info(
+          `Cache hit for path ${assetCachePath}/${firstFile} in ${seconds *
+            1000 +
+            nanoSeconds / 1e6} ms`
+        );
+
+      return {
+        status: "cached",
+        fromCache: true,
+        path: `${assetCachePath}/${firstFile}`,
+        contentType,
+        contentLength
+      };
+    }
+
+    const response = await fetch(fetchUrl);
+
+    // Never cache non-2xx responses: report the upstream status, content-type
+    // and body so the caller can surface the real error. Reading the body also
+    // releases the keep-alive socket. The entry self-heals on the next call.
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        status: "error",
+        httpStatus: response.status,
+        statusText: response.statusText,
+        contentType: response.headers.get("content-type"),
+        body
+      };
+    }
+
+    // A 2xx response can carry no content to cache (204/205, or a null body).
+    // Report the status and short-circuit rather than caching an empty file.
+    if (response.status === 204 || response.status === 205 || !response.body) {
+      return { status: "empty", httpStatus: response.status };
+    }
+
+    // node 10 supports recursive: true, but who knows?
+    middleWare.makeDirIfNotExists(cacheDir);
+    middleWare.makeDirIfNotExists(path.join(cacheDir, dir1));
+    middleWare.makeDirIfNotExists(path.join(cacheDir, dir1, dir2));
+    middleWare.makeDirIfNotExists(path.join(cacheDir, dir1, dir2, dir3));
+
+    const contentType = response.headers.get("content-type") || "";
+    const totalHeader = response.headers.get("content-length");
+    const total =
+      totalHeader != null && totalHeader !== ""
+        ? parseInt(totalHeader, 10)
+        : null;
+
+    // Stream to a temp file in the same directory, then atomically rename into
+    // place. A crashed or partial download never corrupts the cache.
+    tmpPath = `${assetCachePath}/.tmp-${crypto.randomBytes(8).toString("hex")}`;
+
+    let received = 0;
+    const counter = new Transform({
+      transform(chunk, _encoding, callback) {
+        received += chunk.length;
+        if (typeof opts.onProgress === "function") {
+          opts.onProgress({ received, total });
+        }
+        callback(null, chunk);
+      }
+    });
+
+    // On failure the outer catch removes tmpPath. A partial temp file is never
+    // renamed into place, so the published cache can't be corrupted.
+    await streamPipeline(response.body, counter, fs.createWriteStream(tmpPath));
+
+    // The number of bytes actually written is authoritative (the
+    // Content-Length header may be missing or wrong for chunked responses).
+    const contentLength = received;
+    const fileName = middleWare.encodeAssetCacheName(
+      contentType,
+      contentLength
+    );
+    const finalPath = `${assetCachePath}/${fileName}`;
+
+    middleWare.evictLeastRecentlyUsed(cacheDir, maxSize, logger);
+
+    try {
+      fs.renameSync(tmpPath, finalPath);
+    } catch (renameErr) {
+      if (renameErr.code === "EEXIST") {
+        // A concurrent call for the same key already published this asset.
+        // Windows rename refuses to overwrite an existing file, so drop our
+        // temp copy and use the one that is already there.
+        try {
+          fs.unlinkSync(tmpPath);
+        } catch (_) {
+          // ignore cleanup errors
+        }
+      } else {
+        throw renameErr;
+      }
+    }
+    // The temp file is gone (renamed or unlinked); nothing left to clean up.
+    tmpPath = undefined;
+
+    const [seconds, nanoSeconds] = process.hrtime(startTime);
+    if (logger)
+      logger.info(
+        `Wrote asset to path ${finalPath} in ${seconds * 1000 +
+          nanoSeconds / 1e6} ms`
+      );
+
+    return {
+      status: "cached",
+      fromCache: false,
+      path: finalPath,
+      contentType,
+      contentLength: String(contentLength)
+    };
+  } catch (e) {
+    // Remove only this call's partial temp file. Never remove the shared cache
+    // directory: a concurrent call for the same key may have just published a
+    // valid file there.
+    if (tmpPath) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch (_) {
+        // ignore cleanup errors
+      }
+    }
+
+    if (logger)
+      logger.error(
+        `Caching asset at ${assetCachePath} failed with error: ${e.message}`
+      );
+
+    throw e;
+  }
+}
+
 const middleWare = (module.exports = function(options) {
   return async function(req, res, next) {
     options = options || {};
-    options.cacheDir =
-      options && options.cacheDir
-        ? options.cacheDir
-        : path.join(process.cwd(), "/tmp");
-    options.maxSize =
-      options && options.maxSize ? options.maxSize : 1024 * 1024 * 1024;
-
-    const {
-      dir1,
-      dir2,
-      dir3,
-      path: assetCachePath
-    } = middleWare.makeAssetCachePath(
-      options.cacheDir,
-      res.locals.cacheKey || res.locals.fetchUrl
-    );
-
-    // Scoped here so the catch block can clean up this request's temp file
-    // without removing the shared cache directory, which a concurrent request
-    // for the same key may be using.
-    let tmpPath;
-    const startTime = process.hrtime();
 
     try {
-      if (fs.existsSync(assetCachePath)) {
-        const firstFile = fs.readdirSync(assetCachePath)[0];
+      const result = await middleWare.cacheAsset(res.locals.fetchUrl, {
+        cacheDir: options.cacheDir,
+        cacheKey: res.locals.cacheKey,
+        maxSize: options.maxSize,
+        onProgress: options.onProgress,
+        logger: options.logger
+      });
 
-        // Empty directory = corrupted cache entry, re-fetch
-        if (!firstFile) {
-          fs.rmdirSync(assetCachePath);
-          // Fall through to the fetch path by pretending the dir doesn't exist
-          return middleWare(options)(req, res, next);
+      // Forward the upstream error to the client so it sees the real failure.
+      // Nothing was cached; the entry self-heals on the next request.
+      if (result.status === "error") {
+        if (result.contentType && typeof res.set === "function") {
+          res.set("Content-Type", result.contentType);
         }
-
-        // touch file for LRU eviction
-        middleWare.touch(`${assetCachePath}/${firstFile}`);
-
-        const [contentType, contentLength] = middleWare.decodeAssetCacheName(
-          firstFile
-        );
-
-        res.locals.contentLength = contentLength;
-        res.locals.contentType = contentType;
-
-        res.locals.buffer = fs.readFileSync(`${assetCachePath}/${firstFile}`);
-
-        const [seconds, nanoSeconds] = process.hrtime(startTime);
-        if (options.logger)
-          options.logger.info(
-            `Read buffer from path ${assetCachePath}/${firstFile} in ${seconds *
-              1000 +
-              nanoSeconds / 1e6} ms`
-          );
-      } else {
-        const response = await fetch(res.locals.fetchUrl);
-
-        // Never cache non-2xx responses: forward the upstream status,
-        // content-type and body so the client sees the real error. Reading the
-        // body also releases the keep-alive socket. The entry self-heals on the
-        // next request.
-        if (!response.ok) {
-          const upstreamType = response.headers.get("content-type");
-          if (upstreamType && typeof res.set === "function") {
-            res.set("Content-Type", upstreamType);
-          }
-          const body = await response.text();
-          return res
-            .status(response.status)
-            .send(body || response.statusText || "Upstream error");
-        }
-
-        // A 2xx response can carry no content to cache (204/205, or a null
-        // body). Respond with the status and short-circuit rather than caching
-        // an empty file.
-        if (
-          response.status === 204 ||
-          response.status === 205 ||
-          !response.body
-        ) {
-          return res.status(response.status).end();
-        }
-
-        // node 10 supports recursive: true, but who knows?
-        middleWare.makeDirIfNotExists(options.cacheDir);
-        middleWare.makeDirIfNotExists(path.join(options.cacheDir, dir1));
-        middleWare.makeDirIfNotExists(path.join(options.cacheDir, dir1, dir2));
-        middleWare.makeDirIfNotExists(
-          path.join(options.cacheDir, dir1, dir2, dir3)
-        );
-
-        const contentType = response.headers.get("content-type") || "";
-        const totalHeader = response.headers.get("content-length");
-        const total =
-          totalHeader != null && totalHeader !== ""
-            ? parseInt(totalHeader, 10)
-            : null;
-
-        // Stream to a temp file in the same directory, then atomically rename
-        // into place. A crashed or partial download never corrupts the cache.
-        tmpPath = `${assetCachePath}/.tmp-${crypto
-          .randomBytes(8)
-          .toString("hex")}`;
-
-        let received = 0;
-        const counter = new Transform({
-          transform(chunk, _encoding, callback) {
-            received += chunk.length;
-            if (typeof options.onProgress === "function") {
-              options.onProgress({ received, total });
-            }
-            callback(null, chunk);
-          }
-        });
-
-        // On failure the outer catch removes tmpPath. A partial temp file is
-        // never renamed into place, so the published cache can't be corrupted.
-        await streamPipeline(
-          response.body,
-          counter,
-          fs.createWriteStream(tmpPath)
-        );
-
-        // The number of bytes actually written is authoritative (the
-        // Content-Length header may be missing or wrong for chunked responses).
-        const contentLength = received;
-        const fileName = middleWare.encodeAssetCacheName(
-          contentType,
-          contentLength
-        );
-        const finalPath = `${assetCachePath}/${fileName}`;
-
-        middleWare.evictLeastRecentlyUsed(
-          options.cacheDir,
-          options.maxSize,
-          options.logger
-        );
-
-        try {
-          fs.renameSync(tmpPath, finalPath);
-        } catch (renameErr) {
-          if (renameErr.code === "EEXIST") {
-            // A concurrent request for the same key already published this
-            // asset. Windows rename refuses to overwrite an existing file, so
-            // drop our temp copy and serve the one that is already there.
-            try {
-              fs.unlinkSync(tmpPath);
-            } catch (_) {
-              // ignore cleanup errors
-            }
-          } else {
-            throw renameErr;
-          }
-        }
-        // The temp file is gone (renamed or unlinked); nothing left to clean up.
-        tmpPath = undefined;
-
-        res.locals.contentType = contentType;
-        res.locals.contentLength = String(contentLength);
-        res.locals.buffer = fs.readFileSync(finalPath);
-
-        const [seconds, nanoSeconds] = process.hrtime(startTime);
-        if (options.logger)
-          options.logger.info(
-            `Wrote buffer to path ${finalPath} in ${seconds * 1000 +
-              nanoSeconds / 1e6} ms`
-          );
+        return res
+          .status(result.httpStatus)
+          .send(result.body || result.statusText || "Upstream error");
       }
+
+      // 2xx carrying nothing to cache (204/205, or a null body).
+      if (result.status === "empty") {
+        return res.status(result.httpStatus).end();
+      }
+
+      res.locals.contentType = result.contentType;
+      res.locals.contentLength = result.contentLength;
+      res.locals.buffer = fs.readFileSync(result.path);
 
       if (res && typeof res.set === "function") {
         res.set("Accept-Ranges", "bytes");
@@ -374,27 +434,13 @@ const middleWare = (module.exports = function(options) {
 
       next();
     } catch (e) {
-      // Remove only this request's partial temp file. Never remove the shared
-      // cache directory: a concurrent request for the same key may have just
-      // published a valid file there.
-      if (tmpPath) {
-        try {
-          fs.unlinkSync(tmpPath);
-        } catch (_) {
-          // ignore cleanup errors
-        }
-      }
-
-      if (options.logger)
-        options.logger.error(
-          `Caching asset at ${assetCachePath} failed with error: ${e.message}`
-        );
-
+      // cacheAsset already removed its temp file and logged the cause.
       res.status(500).send(e.message);
     }
   };
 });
 
+middleWare.cacheAsset = cacheAsset;
 middleWare.makeAssetCachePath = makeAssetCachePath;
 middleWare.makeDirIfNotExists = makeDirIfNotExists;
 middleWare.encodeAssetCacheName = encodeAssetCacheName;

--- a/test/cache-asset.test.mjs
+++ b/test/cache-asset.test.mjs
@@ -1,0 +1,247 @@
+import * as chai from "chai";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import http from "http";
+import crypto from "crypto";
+
+import middleware from "../index.js";
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+// The documented entry point for non-Express callers.
+const { cacheAsset } = middleware;
+
+// Tests for the standalone cacheAsset(url, opts) API (issue #48): the
+// fetch+cache core without an Express req/res. Like streaming.test.mjs these
+// run against a real local HTTP server and a real temp cache directory.
+describe("cacheAsset (integration)", function() {
+  const ASSET = crypto.randomBytes(64 * 1024); // 64 KiB
+
+  let server;
+  let baseUrl;
+  let cacheDir;
+  let originalEvict;
+  let hits; // upstream request count per URL path
+
+  before(function(done) {
+    // See streaming.test.mjs: eviction's async folder scan races the per-test
+    // temp dir cleanup. It has its own coverage there.
+    originalEvict = middleware.evictLeastRecentlyUsed;
+    middleware.evictLeastRecentlyUsed = () => {};
+
+    server = http.createServer((req, res) => {
+      hits[req.url] = (hits[req.url] || 0) + 1;
+
+      if (req.url === "/asset") {
+        res.writeHead(200, {
+          "Content-Type": "image/png",
+          "Content-Length": ASSET.length
+        });
+        res.end(ASSET);
+      } else if (req.url === "/chunked") {
+        // No Content-Length -> chunked transfer encoding -> total is null.
+        res.writeHead(200, { "Content-Type": "application/octet-stream" });
+        res.write(ASSET.subarray(0, ASSET.length / 2));
+        res.write(ASSET.subarray(ASSET.length / 2));
+        res.end();
+      } else if (req.url === "/truncated") {
+        // Promises a full body, then dies mid-stream.
+        res.writeHead(200, {
+          "Content-Type": "image/png",
+          "Content-Length": ASSET.length
+        });
+        res.write(ASSET.subarray(0, 1024));
+        res.destroy();
+      } else if (req.url === "/empty") {
+        res.writeHead(204);
+        res.end();
+      } else if (req.url === "/404") {
+        res.writeHead(404, { "Content-Type": "text/html" });
+        res.end("<h1>Not Found</h1>");
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      baseUrl = `http://127.0.0.1:${server.address().port}`;
+      done();
+    });
+  });
+
+  after(function(done) {
+    middleware.evictLeastRecentlyUsed = originalEvict;
+    server.close(done);
+  });
+
+  beforeEach(function() {
+    hits = {};
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cache-asset-test-"));
+  });
+
+  afterEach(function() {
+    sinon.restore();
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  // Every file in the cache directory, temp files included.
+  function cachedFiles(dir) {
+    const walk = d =>
+      fs.readdirSync(d).flatMap(entry => {
+        const p = path.join(d, entry);
+        return fs.statSync(p).isDirectory() ? walk(p) : [p];
+      });
+    return fs.existsSync(dir) ? walk(dir) : [];
+  }
+
+  it("caches a fresh URL and reports it as a miss", async function() {
+    const result = await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+
+    expect(result.status).to.equal("cached");
+    expect(result.fromCache).to.equal(false);
+    expect(result.contentType).to.equal("image/png");
+    expect(result.contentLength).to.equal(String(ASSET.length));
+
+    expect(fs.existsSync(result.path), "the returned path exists").to.equal(
+      true
+    );
+    expect(fs.readFileSync(result.path).equals(ASSET)).to.equal(true);
+  });
+
+  it("reports monotonic progress up to the total", async function() {
+    const events = [];
+    await cacheAsset(`${baseUrl}/asset`, {
+      cacheDir,
+      onProgress: ({ received, total }) => events.push({ received, total })
+    });
+
+    expect(events.length).to.be.greaterThan(0);
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].received).to.be.at.least(events[i - 1].received);
+    }
+    expect(events.every(e => e.total === ASSET.length)).to.equal(true);
+    expect(events[events.length - 1].received).to.equal(ASSET.length);
+  });
+
+  it("reports a null total when upstream sends no Content-Length", async function() {
+    const events = [];
+    const result = await cacheAsset(`${baseUrl}/chunked`, {
+      cacheDir,
+      onProgress: p => events.push(p)
+    });
+
+    expect(events.every(e => e.total === null)).to.equal(true);
+    // The bytes actually received are authoritative for the cached length.
+    expect(result.contentLength).to.equal(String(ASSET.length));
+  });
+
+  it("serves the second call from cache without hitting the network", async function() {
+    const first = await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+    const second = await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+
+    expect(first.fromCache).to.equal(false);
+    expect(second.fromCache).to.equal(true);
+    expect(second.status).to.equal("cached");
+    expect(second.path).to.equal(first.path);
+    expect(second.contentType).to.equal("image/png");
+    expect(second.contentLength).to.equal(String(ASSET.length));
+    expect(hits["/asset"], "upstream is fetched exactly once").to.equal(1);
+  });
+
+  it("touches the cached file on a hit so LRU sees the access", async function() {
+    const first = await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+    const touchSpy = sinon.spy(middleware, "touch");
+
+    await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+
+    expect(touchSpy).to.have.been.calledOnceWithExactly(first.path);
+  });
+
+  it("keys the cache by cacheKey when given", async function() {
+    const viaKey = await cacheAsset(`${baseUrl}/asset`, {
+      cacheDir,
+      cacheKey: "stable-key"
+    });
+    // A different URL under the same key resolves to the same entry, without
+    // a second upstream fetch.
+    const again = await cacheAsset(`${baseUrl}/chunked`, {
+      cacheDir,
+      cacheKey: "stable-key"
+    });
+
+    expect(again.fromCache).to.equal(true);
+    expect(again.path).to.equal(viaKey.path);
+    expect(hits["/chunked"], "the second URL is never fetched").to.equal(
+      undefined
+    );
+  });
+
+  it("reports a non-2xx upstream as an error and caches nothing", async function() {
+    const result = await cacheAsset(`${baseUrl}/404`, { cacheDir });
+
+    expect(result.status).to.equal("error");
+    expect(result.httpStatus).to.equal(404);
+    expect(result.contentType).to.match(/text\/html/);
+    expect(result.body).to.contain("Not Found");
+    expect(cachedFiles(cacheDir), "nothing should be cached").to.deep.equal([]);
+  });
+
+  it("reports a 2xx with no body as empty and caches nothing", async function() {
+    const result = await cacheAsset(`${baseUrl}/empty`, { cacheDir });
+
+    expect(result.status).to.equal("empty");
+    expect(result.httpStatus).to.equal(204);
+    expect(cachedFiles(cacheDir), "nothing should be cached").to.deep.equal([]);
+  });
+
+  it("leaves no temp file behind when the download dies mid-stream", async function() {
+    let rejected = null;
+    try {
+      await cacheAsset(`${baseUrl}/truncated`, { cacheDir });
+    } catch (e) {
+      rejected = e;
+    }
+
+    // node-fetch rejects with a FetchError, which chai's `an("error")` does
+    // not recognise as an Error; check the prototype chain instead.
+    expect(rejected, "cacheAsset should reject").to.be.instanceOf(Error);
+    expect(
+      cachedFiles(cacheDir),
+      "no partial entry and no temp file"
+    ).to.deep.equal([]);
+  });
+
+  it("leaves no temp file behind when publishing fails", async function() {
+    sinon.stub(fs, "renameSync").throws(new Error("EIO"));
+
+    let rejected = null;
+    try {
+      await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+    } catch (e) {
+      rejected = e;
+    }
+
+    expect(rejected, "cacheAsset should reject").to.be.an("error");
+    expect(rejected.message).to.equal("EIO");
+    expect(cachedFiles(cacheDir), "the temp file is removed").to.deep.equal([]);
+  });
+
+  it("re-fetches when the cache entry is an empty directory", async function() {
+    const { path: assetCachePath } = middleware.makeAssetCachePath(
+      cacheDir,
+      `${baseUrl}/asset`
+    );
+    // A corrupted entry: the directory exists but holds no file.
+    fs.mkdirSync(assetCachePath, { recursive: true });
+
+    const result = await cacheAsset(`${baseUrl}/asset`, { cacheDir });
+
+    expect(result.status).to.equal("cached");
+    expect(result.fromCache).to.equal(false);
+    expect(fs.readFileSync(result.path).equals(ASSET)).to.equal(true);
+  });
+});


### PR DESCRIPTION
Closes #48. Targeting 1.6.0.

## What

Moves the fetch+cache core out of the `(req, res, next)` middleware into a standalone, exported `cacheAsset(url, opts)`, and reduces the middleware to a thin adapter over it. One home for the download/temp-file/atomic-rename/progress logic; both consumers share it.

```js
const { cacheAsset } = require("express-asset-file-cache-middleware");

const result = await cacheAsset("https://cdn.example.org/big-video.mp4", {
  cacheDir: "/tmp",
  cacheKey: someExpirableUniqueKey,      // optional, falls back to the URL
  onProgress: ({ received, total }) => { /* -> IPC progress event */ }
});
```

It resolves to a tagged result rather than throwing on upstream failures, so a caller can tell an upstream 404 from a broken disk:

| `status` | Fields |
| --- | --- |
| `"cached"` | `fromCache`, `path`, `contentType`, `contentLength` |
| `"error"` | `httpStatus`, `statusText`, `contentType`, `body` — nothing cached |
| `"empty"` | `httpStatus` — 204/205 or null body, nothing cached |

Filesystem and stream errors reject, after `cacheAsset` unlinks its own temp file (never the shared cache dir).

The middleware now maps `"cached"` → `res.locals` + `next()`, `"error"` → the forwarded upstream status/content-type/body, `"empty"` → `res.status(...).end()`. `options.onProgress` passes straight through; Range support via `sendBuffer` is untouched.

## Behaviour

Unchanged, by design. Cache semantics, LRU `touch`/eviction, atomic rename, the EEXIST-on-Windows path and temp-file cleanup all moved verbatim. Two deliberate deviations, both internal:

- Defaults for `cacheDir`/`maxSize` now resolve inside `cacheAsset` instead of mutating the caller's `options` object.
- Two logger lines were reworded (`Read buffer from path …` → `Cache hit for path …`, `Wrote buffer to path …` → `Wrote asset to path …`) since the buffer read now happens in the adapter. Nothing asserts on log text.

## Tests

`test/streaming.test.mjs`, `test/test.mjs` and `test/touch.test.mjs` are **byte-for-byte unchanged** and pass as-is — that is the regression evidence that the adapter refactor preserves behaviour (`git diff --stat -- test/` on the refactor commit is empty apart from the new file).

New `test/cache-asset.test.mjs` covers the API directly against a real local HTTP server and a real temp cache dir (11 cases):

- fresh URL caches; `fromCache: false`, correct `contentType`/`contentLength`, bytes on disk match
- `onProgress` fires with monotonically increasing `received` ending at `total`
- chunked response (no `Content-Length`) reports `total: null`; received bytes are authoritative for the cached length
- second call returns `fromCache: true` and does **not** hit the network (upstream request counter stays at 1)
- cache hit `touch`es the file for LRU
- `cacheKey` overrides the URL as the dedupe key
- non-2xx → `{ status: "error" }`, nothing cached
- 204 → `{ status: "empty" }`, nothing cached
- upstream dying mid-stream → rejects, no temp file and no partial entry left
- publish failure (rename throws) → rejects, temp file removed
- empty cache directory (corrupted entry) re-fetches

46 passing locally.

## Not in this PR

- The 1.6.0 version bump — lands on `master` after merge, matching how 1.5.0 shipped.
- Slimming `streaming.test.mjs`: six of its cases now test the core through the middleware and duplicate `cache-asset.test.mjs`. Kept as-is here on purpose (see above); follow-up issue to move them down a layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)