### PR TITLE
Coalesce concurrent cache misses into a single fetch (#54)

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,10 +226,12 @@ function findLeastRecentlyUsed(dir, result) {
 /**
  * Fetch an asset and cache it on disk, or resolve it straight from the cache.
  *
- * This is the whole download/cache/progress core with no HTTP transport
- * attached, so a non-Express caller (an Electron main process, a CLI precache,
- * a queue worker) can use it directly. The middleware below is a thin adapter
- * over it.
+ * This is the internal download/cache/progress core with no HTTP transport
+ * attached. Public callers - including non-Express ones (an Electron main
+ * process, a CLI precache, a queue worker) - go through the exported cacheAsset
+ * wrapper below, which adds request coalescing; the middleware is a thin
+ * adapter over that. A result object returned here may be shared across
+ * coalesced callers, so treat it as read-only.
  *
  * @param {string} fetchUrl
  * @param {object} [opts]

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ function findLeastRecentlyUsed(dir, result) {
  * >}
  *   Rejects on filesystem/stream errors, after unlinking its own temp file.
  */
-async function cacheAsset(fetchUrl, opts) {
+async function cacheAssetInner(fetchUrl, opts) {
   opts = opts || {};
   const cacheDir = opts.cacheDir || path.join(process.cwd(), "/tmp");
   const maxSize = opts.maxSize || 1024 * 1024 * 1024;
@@ -432,6 +432,47 @@ async function cacheAsset(fetchUrl, opts) {
   }
 }
 
+// Concurrent cache MISSES for the same cache location would otherwise each run
+// their own upstream fetch and race their own temp files into the same final
+// name. This map coalesces them: the first caller to reach a given resolved
+// cache path starts the populate, and every concurrent caller for that same
+// path awaits the one shared promise instead of fetching again (#54). The entry
+// is removed as soon as that promise settles, so a later request re-populates
+// or hits the cache normally.
+const inFlight = new Map();
+
+/**
+ * Public entry point. Same arguments and return contract as cacheAssetInner
+ * (see its JSDoc above), plus request coalescing.
+ *
+ * Coalescing is keyed by the resolved assetCachePath - derived from (cacheDir,
+ * cacheKey) - so two calls share a fetch only when they target the exact same
+ * cache entry. A coalesced (secondary) caller receives the winner's result but
+ * does NOT run its own fetch, so only the first caller's onProgress / logger
+ * fire for that download. If the shared populate rejects (or resolves to an
+ * "error"/"empty" result), every awaiter observes the same outcome.
+ */
+async function cacheAsset(fetchUrl, opts) {
+  opts = opts || {};
+  const cacheDir = opts.cacheDir || path.join(process.cwd(), "/tmp");
+  const cacheKey = opts.cacheKey || fetchUrl;
+  const { path: assetCachePath } = middleWare.makeAssetCachePath(
+    cacheDir,
+    cacheKey
+  );
+
+  const existing = inFlight.get(assetCachePath);
+  if (existing) return existing;
+
+  const pending = middleWare.cacheAssetInner(fetchUrl, opts);
+  inFlight.set(assetCachePath, pending);
+  try {
+    return await pending;
+  } finally {
+    inFlight.delete(assetCachePath);
+  }
+}
+
 const middleWare = (module.exports = function(options) {
   return async function(req, res, next) {
     options = options || {};
@@ -481,6 +522,9 @@ const middleWare = (module.exports = function(options) {
 });
 
 middleWare.cacheAsset = cacheAsset;
+middleWare.cacheAssetInner = cacheAssetInner;
+// Exposed for tests to assert the coalescing map drains after each request.
+middleWare._inFlight = inFlight;
 middleWare.makeAssetCachePath = makeAssetCachePath;
 middleWare.makeDirIfNotExists = makeDirIfNotExists;
 middleWare.encodeAssetCacheName = encodeAssetCacheName;

--- a/test/cache-asset.test.mjs
+++ b/test/cache-asset.test.mjs
@@ -86,6 +86,9 @@ describe("cacheAsset (integration)", function() {
   afterEach(function() {
     sinon.restore();
     fs.rmSync(cacheDir, { recursive: true, force: true });
+    // The coalescing map drains itself, but clear it defensively so a test
+    // that threw mid-flight can't leak an entry into the next one (#54).
+    middleware._inFlight.clear();
   });
 
   // Every file in the cache directory, temp files included.
@@ -243,5 +246,69 @@ describe("cacheAsset (integration)", function() {
     expect(result.status).to.equal("cached");
     expect(result.fromCache).to.equal(false);
     expect(fs.readFileSync(result.path).equals(ASSET)).to.equal(true);
+  });
+
+  // Request coalescing (issue #54): concurrent callers that resolve to the same
+  // cache entry share a single upstream fetch instead of each running their own.
+  describe("coalescing concurrent misses (#54)", function() {
+    it("coalesces concurrent misses into a single upstream fetch", async function() {
+      const [a, b] = await Promise.all([
+        cacheAsset(`${baseUrl}/asset`, { cacheDir }),
+        cacheAsset(`${baseUrl}/asset`, { cacheDir })
+      ]);
+
+      expect(hits["/asset"], "upstream fetched exactly once").to.equal(1);
+      expect(a.status).to.equal("cached");
+      expect(b.status).to.equal("cached");
+      expect(a.path).to.equal(b.path);
+      expect(fs.readFileSync(a.path).equals(ASSET)).to.equal(true);
+      // A single published entry, and the in-flight map has drained.
+      expect(cachedFiles(cacheDir).length).to.equal(1);
+      expect(middleware._inFlight.size).to.equal(0);
+    });
+
+    it("shares one fetch and gives every caller the same error result", async function() {
+      const [a, b] = await Promise.all([
+        cacheAsset(`${baseUrl}/404`, { cacheDir }),
+        cacheAsset(`${baseUrl}/404`, { cacheDir })
+      ]);
+
+      expect(hits["/404"], "upstream fetched once for both").to.equal(1);
+      expect(a.status).to.equal("error");
+      expect(b.status).to.equal("error");
+      expect(a.httpStatus).to.equal(404);
+      expect(middleware._inFlight.size).to.equal(0);
+    });
+
+    it("propagates a mid-stream failure to every coalesced caller and drains the map", async function() {
+      const [a, b] = await Promise.allSettled([
+        cacheAsset(`${baseUrl}/truncated`, { cacheDir }),
+        cacheAsset(`${baseUrl}/truncated`, { cacheDir })
+      ]);
+
+      expect(hits["/truncated"], "one shared fetch").to.equal(1);
+      expect(a.status).to.equal("rejected");
+      expect(b.status).to.equal("rejected");
+      // Both awaiters observe the same error instance from the shared populate.
+      expect(a.reason).to.equal(b.reason);
+      expect(cachedFiles(cacheDir), "no partial entry left behind").to.deep.equal(
+        []
+      );
+      expect(middleware._inFlight.size, "map drained after rejection").to.equal(
+        0
+      );
+    });
+
+    it("does not coalesce calls that resolve to different cache entries", async function() {
+      const [a, b] = await Promise.all([
+        cacheAsset(`${baseUrl}/asset`, { cacheDir, cacheKey: "k1" }),
+        cacheAsset(`${baseUrl}/asset`, { cacheDir, cacheKey: "k2" })
+      ]);
+
+      // Same URL, different keys -> two distinct entries -> two fetches.
+      expect(hits["/asset"]).to.equal(2);
+      expect(a.path).to.not.equal(b.path);
+      expect(middleware._inFlight.size).to.equal(0);
+    });
   });
 });

--- a/test/cache-asset.test.mjs
+++ b/test/cache-asset.test.mjs
@@ -310,5 +310,37 @@ describe("cacheAsset (integration)", function() {
       expect(a.path).to.not.equal(b.path);
       expect(middleware._inFlight.size).to.equal(0);
     });
+
+    it("coalesces N concurrent callers into a single fetch", async function() {
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          cacheAsset(`${baseUrl}/asset`, { cacheDir })
+        )
+      );
+
+      expect(hits["/asset"], "one fetch for all five callers").to.equal(1);
+      expect(results.every(r => r.status === "cached")).to.equal(true);
+      const paths = new Set(results.map(r => r.path));
+      expect(paths.size, "all share the one published entry").to.equal(1);
+      expect(middleware._inFlight.size).to.equal(0);
+    });
+
+    it("gives concurrent same-key callers the first URL's content (first-wins)", async function() {
+      // Same cacheKey + different URLs: consistent with the sequential cacheKey
+      // contract (the second URL is never fetched), now applied deterministically
+      // to the concurrent case. Promise.all invokes the /asset call first, so it
+      // wins and /chunked is never fetched.
+      const [a, b] = await Promise.all([
+        cacheAsset(`${baseUrl}/asset`, { cacheDir, cacheKey: "shared" }),
+        cacheAsset(`${baseUrl}/chunked`, { cacheDir, cacheKey: "shared" })
+      ]);
+
+      expect(a.path).to.equal(b.path);
+      expect(hits["/asset"], "the winner is fetched once").to.equal(1);
+      expect(hits["/chunked"], "the second URL is never fetched").to.equal(
+        undefined
+      );
+      expect(middleware._inFlight.size).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
Closes #54.

Concurrent callers that resolve to the same cache location each ran their own upstream fetch (and raced their own temp files into the same final name). This coalesces them: the first caller to reach a given resolved cache path starts the populate, and every concurrent caller for that same path awaits the one shared promise.

## Approach (deliberately low-risk)
The ~180-line download/cache/progress core is left **byte-identical** — renamed to `cacheAssetInner`. The public `cacheAsset` becomes a thin wrapper around it:

```js
async function cacheAsset(fetchUrl, opts) {
  // resolve assetCachePath from (cacheDir, cacheKey)
  const existing = inFlight.get(assetCachePath);
  if (existing) return existing;
  const pending = middleWare.cacheAssetInner(fetchUrl, opts);
  inFlight.set(assetCachePath, pending);
  try { return await pending; } finally { inFlight.delete(assetCachePath); }
}
```

- **Keyed by the resolved `assetCachePath`** (derived from `cacheDir` + `cacheKey`), so two calls share a fetch only when they target the exact same entry — different keys/dirs never falsely coalesce.
- **Self-draining**: the entry is deleted in a `finally`, so a rejection or an `"error"`/`"empty"` result is observed by every awaiter and a later request re-populates or hits the cache normally.
- The map set happens synchronously before the fetch's first `await`, so coalescing is deterministic, not timing-dependent.

## Tradeoff (please sanity-check)
A coalesced **secondary** caller receives the winner's result but does **not** run its own fetch — so only the **first** caller's `onProgress` / `logger` fire for that download. That's inherent to request coalescing; documented in the code. If per-caller progress fan-out is wanted, it can be a follow-up.

## Tests (`test/cache-asset.test.mjs`)
- concurrent misses → **one** upstream fetch and one published entry;
- a shared **error** (404) result reaches every caller (one fetch);
- a **mid-stream failure** rejects every awaiter with the *same* error instance, leaves no partial entry, and drains the map;
- calls under **different `cacheKey`s are not coalesced** (guard against over-coalescing).

The coalescing assertions fail against the pre-#54 code. Full suite: **59 passing.**

Branches from `master` and is independent of PR #58 (the #55/#56 quick-wins); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
